### PR TITLE
typo with labelValues (#1)

### DIFF
--- a/src/Collector/Counter.php
+++ b/src/Collector/Counter.php
@@ -84,7 +84,7 @@ class Counter implements CollectorInterface
             throw new PrometheusException("Increment must be positive");
         }
         Validator::validateLabelValues($labelValues, $this->labelNames);
-        $this->storage->incValue($this->name, $v, is_int($v) ? 0 : 0.0, $this->labelNames);
+        $this->storage->incValue($this->name, $v, is_int($v) ? 0 : 0.0, $labelValues);
 
         return $this;
     }

--- a/src/Collector/Gauge.php
+++ b/src/Collector/Gauge.php
@@ -109,7 +109,7 @@ class Gauge implements CollectorInterface
                 return 0;
             }
         };
-        $this->storage->incValue($this->name, $v, $default, $this->labelNames);
+        $this->storage->incValue($this->name, $v, $default, $labelValues);
 
         return $this;
     }


### PR DESCRIPTION
It's a definitely typo because dec() method contains a correct callback.