### PR TITLE
Feature/fix histogram

### DIFF
--- a/src/Collector/Histogram.php
+++ b/src/Collector/Histogram.php
@@ -127,7 +127,7 @@ class Histogram implements CollectorInterface
 
         $samples = [];
         foreach ($this->storage->getValues($this->name) as $row) {
-            $samples[] = new Sample($this->name, array_merge(['le'], $this->labelNames), $row[1], $row[0]);
+            $samples[] = new Sample("{$this->name}_bucket", array_merge(['le'], $this->labelNames), $row[1], $row[0]);
         }
 
         return [

--- a/src/Collector/Histogram.php
+++ b/src/Collector/Histogram.php
@@ -108,7 +108,7 @@ class Histogram implements CollectorInterface
         $this->storage->incValue($this->name.self::SUM_POSTFIX, $v, is_int($v) ? 0 : 0.0, $labelValues);
         foreach ($this->buckets as $bucketMax) {
             if ($v <= $bucketMax) {
-                $this->storage->incValue($this->name, 1, 0, array_merge([$bucketMax], $labelValues));
+                $this->storage->incValue($this->name, 1, 0, array_merge([strval($bucketMax)], $labelValues));
             }
         }
 


### PR DESCRIPTION
We encountered a problem with the histograms after upgrading php to 7.1. The problem is the change of precision serializing floats. See https://wiki.php.net/rfc/precise_float_value. As a result we had two different entries at redis for the same bucket.

> php > ini_set('serialize_precision', 17);
> php > echo json_encode([6.8, "label1", "label2"]);
> [6.7999999999999998,"label1","label2"]

> php > ini_set('serialize_precision', 14);
> php > echo json_encode([6.8, "label1", "label2"]);
> [6.8,"label1","label2"]

We fixed the problem by "strval" the "le" label value.

Additionally we suffixed the observation buckets name with "_bucket" according to Prometheus specs.
See: https://prometheus.io/docs/concepts/metric_types/#histogram

Attention: These changes aren't backwards compatible! You have to clean up your storage after upgrading.