### PR TITLE
Check for "false" returned by opcache_get_status

### DIFF
--- a/src/Util/OpcacheStatsCreator.php
+++ b/src/Util/OpcacheStatsCreator.php
@@ -12,7 +12,7 @@ class OpcacheStatsCreator
         if (function_exists('opcache_get_status')) {
             $stats = opcache_get_status(false);
 
-            if ($stats['opcache_enabled']) {
+            if ($stats !== false && $stats['opcache_enabled']) {
                 $stat = new CallbackGauge('opcache_full');
                 $stat->addCallback(function () use ($stats) {
                     return $stats['cache_full'] ? 1 : 0;


### PR DESCRIPTION
As stated on [https://www.php.net/manual/en/function.opcache-get-status.php](opcache-get-status on php.net) the function opcache_get_status could return `false`.

The following error would be fixed by this PR:
```
Trying to access array offset on value of type bool
.../vendor/tweedegolf/prometheus-client/src/Util/OpcacheStatsCreator.php:15
```
