### PR TITLE
Fix compatibility with PHP 8.2+

### DIFF
--- a/src/Storage/ApcAdapter.php
+++ b/src/Storage/ApcAdapter.php
@@ -67,7 +67,7 @@ class ApcAdapter implements StorageAdapterInterface
      */
     public function getValues($key)
     {
-        $escapedKey = preg_quote("{$this->prefix}||${key}|", '/');
+        $escapedKey = preg_quote("{$this->prefix}||{$key}|", '/');
         $iterator = new \APCIterator('user', "/^{$escapedKey}.*$/");
         $items = [];
         foreach ($iterator as $entry) {

--- a/src/Storage/ApcuAdapter.php
+++ b/src/Storage/ApcuAdapter.php
@@ -70,7 +70,7 @@ class ApcuAdapter implements StorageAdapterInterface
      */
     public function getValues($key)
     {
-        $escapedKey = preg_quote("{$this->prefix}||${key}|", '/');
+        $escapedKey = preg_quote("{$this->prefix}||{$key}|", '/');
         $iterator = new \APCUIterator("/^{$escapedKey}.*$/");
         $items = [];
         foreach ($iterator as $entry) {

--- a/src/Storage/InMemoryAdapter.php
+++ b/src/Storage/InMemoryAdapter.php
@@ -66,7 +66,7 @@ class InMemoryAdapter implements StorageAdapterInterface
      */
     public function getValues($key)
     {
-        $escapedKey = preg_quote("{$this->prefix}||${key}|", '/');
+        $escapedKey = preg_quote("{$this->prefix}||{$key}|", '/');
         $regex = "/^{$escapedKey}.*$/";
         $items = [];
         foreach ($this->data as $key => $value) {


### PR DESCRIPTION
`${var}` syntax is deprecated. Use `{$var}` instead.